### PR TITLE
Add json_schema field and modal for response_format

### DIFF
--- a/src/Modal.css
+++ b/src/Modal.css
@@ -5,15 +5,17 @@
   top: 0;
   width: 100%;
   height: 100%;
-  overflow: hidden;
+  overflow: auto;
   background-color: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .modal>.content {
-  position: relative;
-  top: 50%;
-  left: 50%;
-  transform: translateY(-50%) translateX(-50%);
   background-color: white;
   padding: 20px;
+  margin: 20px;
+  max-height: calc(100vh - 40px);
+  overflow: auto;
 }

--- a/src/OpenAI.jsx
+++ b/src/OpenAI.jsx
@@ -317,6 +317,16 @@ export function createValidator() {
         throw "Logit bias keys must be non-negative integers.";
       }
     }
+    // json_schema response format must have a name and schema.
+    if (p.response_format?.type === "json_schema") {
+      const js = p.response_format.json_schema;
+      if (!js?.name) {
+        throw "JSON Schema response format requires a schema name.";
+      }
+      if (!js?.schema || typeof js.schema !== "object" || Object.keys(js.schema).length === 0) {
+        throw "JSON Schema response format requires a non-empty schema.";
+      }
+    }
   };
 }
 

--- a/src/OpenAI.jsx
+++ b/src/OpenAI.jsx
@@ -371,12 +371,12 @@ export function ReasoningEffortDropdown({ effort, setEffort }) {
         value={effort ? effort : ""}
       >
         <option value="">Default (Medium)</option>
-        {["Low", "Medium", "High"].map((e) => (
+        {["Low", "Medium", "High", "XHigh"].map((e) => (
           <option key={e.toLowerCase()} value={e.toLowerCase()}>
             {e}
           </option>
         ))}
-        {effort && { low: 1, medium: 1, high: 1 }[effort] === undefined && (
+        {effort && { low: 1, medium: 1, high: 1, xhigh: 1 }[effort] === undefined && (
           <>
             <option disabled>Custom</option>
             <option value={effort}>{effort}</option>

--- a/src/ResponseFormatSchemaModal.jsx
+++ b/src/ResponseFormatSchemaModal.jsx
@@ -1,0 +1,232 @@
+import { useRef, useEffect, useState } from 'react';
+import './APIKeyModal.css';
+import { Modal } from './Modal';
+
+const EXAMPLE_NAME = "grade_result";
+const EXAMPLE_SCHEMA = {
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "score": {"type": "number", "enum": [0, 0.5, 1]},
+    "reason": {"type": "string", "minLength": 1, "maxLength": 350}
+  },
+  "required": ["score", "reason"]
+};
+
+export function ResponseFormatSchemaModal({ jsonSchema, onSave, onCancel }) {
+  const nameRef = useRef(null);
+  const schemaRef = useRef(null);
+  const [strict, setStrict] = useState(jsonSchema?.strict ?? true);
+  const [error, setError] = useState("");
+  const [showExample, setShowExample] = useState(false);
+
+  useEffect(() => {
+    if (nameRef.current) {
+      nameRef.current.focus();
+    }
+  }, []);
+
+  const useExample = () => {
+    if (nameRef.current) {
+      nameRef.current.value = EXAMPLE_NAME;
+    }
+    if (schemaRef.current) {
+      schemaRef.current.value = JSON.stringify(EXAMPLE_SCHEMA, null, 2);
+    }
+    setStrict(true);
+    setError("");
+    setShowExample(false);
+  };
+
+
+  const handleSave = () => {
+    const name = nameRef.current.value.trim();
+    const schemaText = schemaRef.current.value.trim();
+
+    if (!name) {
+      setError("Schema name is required");
+      return;
+    }
+
+    if (!schemaText) {
+      setError("JSON Schema is required");
+      return;
+    }
+
+    let parsedSchema;
+    try {
+      parsedSchema = JSON.parse(schemaText);
+    } catch (e) {
+      setError("Invalid JSON: " + e.message);
+      return;
+    }
+
+    setError("");
+    onSave({
+      name: name,
+      schema: parsedSchema,
+      strict: strict
+    });
+  };
+
+  return (
+    <Modal onCancel={onCancel} width="600px" contentClassName="api-key-modal">
+      <h2>Configure JSON Schema</h2>
+      <p>
+        Define a JSON schema to enforce structured output from the model.{" "}
+        <a 
+          href="https://platform.openai.com/docs/guides/structured-outputs" 
+          target="_blank" 
+          rel="noopener"
+        >
+          Learn more
+        </a>
+      </p>
+
+      {/* Example Section */}
+      <div style={{ 
+        marginTop: "16px", 
+        marginBottom: "16px",
+        border: "1px solid #ddd",
+        borderRadius: "4px",
+        backgroundColor: "#f9f9f9"
+      }}>
+        <button
+          onClick={() => setShowExample(!showExample)}
+          style={{
+            width: "100%",
+            textAlign: "left",
+            padding: "10px 12px",
+            background: "transparent",
+            border: "none",
+            cursor: "pointer",
+            fontSize: "14px",
+            fontWeight: "500"
+          }}
+        >
+          {showExample ? "▼" : "▶"} 📖 Show Example
+        </button>
+        
+        {showExample && (
+          <div style={{ padding: "0 12px 12px 12px" }}>
+            <p style={{ fontSize: "13px", marginBottom: "12px" }}>
+              Example: A grading schema that returns a score and reason
+            </p>
+            
+            <div style={{ marginBottom: "8px" }}>
+              <strong style={{ fontSize: "13px" }}>Schema Name:</strong>
+              <div style={{ 
+                fontFamily: "monospace", 
+                fontSize: "12px", 
+                padding: "6px",
+                backgroundColor: "#fff",
+                border: "1px solid #ddd",
+                borderRadius: "3px",
+                marginTop: "4px"
+              }}>
+                {EXAMPLE_NAME}
+              </div>
+            </div>
+
+            <div style={{ marginBottom: "8px" }}>
+              <strong style={{ fontSize: "13px" }}>JSON Schema:</strong>
+              <pre style={{ 
+                fontFamily: "monospace", 
+                fontSize: "12px", 
+                padding: "8px",
+                backgroundColor: "#fff",
+                border: "1px solid #ddd",
+                borderRadius: "3px",
+                marginTop: "4px",
+                overflow: "auto",
+                maxHeight: "200px"
+              }}>
+                {JSON.stringify(EXAMPLE_SCHEMA, null, 2)}
+              </pre>
+            </div>
+
+            <div style={{ marginBottom: "12px" }}>
+              <strong style={{ fontSize: "13px" }}>Strict Mode:</strong> ✓ Enabled
+            </div>
+
+            <button 
+              onClick={useExample}
+              style={{
+                padding: "6px 12px",
+                fontSize: "13px",
+                backgroundColor: "#0066cc",
+                color: "white",
+                border: "none",
+                borderRadius: "4px",
+                cursor: "pointer"
+              }}
+            >
+              ✨ Use This Example
+            </button>
+          </div>
+        )}
+      </div>
+
+      <label style={{ display: "block", marginTop: "16px", marginBottom: "4px" }}>
+        Schema Name:
+      </label>
+
+      <input
+        ref={nameRef}
+        type="text"
+        placeholder="my_schema"
+        defaultValue={jsonSchema?.name || ""}
+        style={{ width: "100%", padding: "8px", fontSize: "14px" }}
+      />
+
+      <label style={{ display: "block", marginTop: "16px", marginBottom: "4px" }}>
+        JSON Schema:
+      </label>
+      <textarea
+        ref={schemaRef}
+        placeholder={'{\n  "type": "object",\n  "properties": {\n    "name": { "type": "string" }\n  },\n  "required": ["name"],\n  "additionalProperties": false\n}'}
+        defaultValue={jsonSchema?.schema ? JSON.stringify(jsonSchema.schema, null, 2) : ""}
+        rows="15"
+        style={{
+          width: "100%",
+          fontFamily: "monospace",
+          fontSize: "13px",
+          padding: "8px",
+          resize: "vertical"
+        }}
+      />
+
+      <label style={{ display: "block", marginTop: "12px", marginBottom: "12px" }}>
+        <input
+          type="checkbox"
+          checked={strict}
+          onChange={(e) => setStrict(e.target.checked)}
+          style={{ marginRight: "8px" }}
+        />
+        Strict Mode (recommended - ensures the output matches the schema exactly)
+      </label>
+
+      {error && (
+        <div
+          style={{
+            color: "#c00",
+            fontSize: "14px",
+            marginTop: "8px",
+            marginBottom: "8px",
+            padding: "8px",
+            backgroundColor: "#fee",
+            borderRadius: "4px"
+          }}
+        >
+          {error}
+        </div>
+      )}
+
+      <div style={{ marginTop: "16px" }}>
+        <button onClick={handleSave}>Save</button>
+        &nbsp;
+        <button onClick={onCancel}>Cancel</button>
+      </div>
+    </Modal>
+  );
+}

--- a/src/ResponseFormatSelector.jsx
+++ b/src/ResponseFormatSelector.jsx
@@ -1,7 +1,9 @@
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 import InfoLabel from "./InfoLabel.jsx";
+import { ResponseFormatSchemaModal } from "./ResponseFormatSchemaModal.jsx";
 
 export function ResponseFormatSelector({ responseFormat, setResponseFormat }) {
+  const [showSchemaModal, setShowSchemaModal] = useState(false);
 
   let value = responseFormat;
   if (value === undefined) {
@@ -14,18 +16,65 @@ export function ResponseFormatSelector({ responseFormat, setResponseFormat }) {
     const v = e.target.value;
     if (v === 'default') {
       setResponseFormat(undefined);
+    } else if (v === 'json_schema') {
+      if (responseFormat?.json_schema?.name) {
+        setResponseFormat({
+          type: v,
+          json_schema: responseFormat.json_schema
+        });
+      } else {
+        setShowSchemaModal(true);
+      }
     } else {
       setResponseFormat({ type: v });
     }
+  }, [setResponseFormat, responseFormat]);
+
+  const handleSchemaSave = useCallback((jsonSchema) => {
+    setResponseFormat({
+      type: "json_schema",
+      json_schema: jsonSchema
+    });
+    setShowSchemaModal(false);
   }, [setResponseFormat]);
 
-  return <><label>Response Format<InfoLabel href="response_format" /></label>
+  const handleSchemaCancel = useCallback(() => {
+    setShowSchemaModal(false);
+  }, []);
+
+  const schemaConfigured = responseFormat?.json_schema?.name;
+
+  return <>
+    <label>Response Format<InfoLabel href="response_format" /></label>
     <select onChange={setType} value={value}>
       <option value="default">
         Default (Text)
       </option>
       <option value="text">Text</option>
       <option value="json_object">JSON</option>
+      <option value="json_schema">JSON Schema</option>
     </select>
+
+    {value === 'json_schema' && (
+      <button
+        onClick={() => setShowSchemaModal(true)}
+        style={{
+          marginTop: "4px",
+          width: "100%",
+          fontSize: "0.9em"
+        }}
+        title={schemaConfigured ? `Schema: ${responseFormat.json_schema.name}` : "Configure JSON Schema"}
+      >
+        ⚙️ {schemaConfigured ? `Schema: ${responseFormat.json_schema.name}` : 'Configure Schema'}
+      </button>
+    )}
+
+    {showSchemaModal && (
+      <ResponseFormatSchemaModal
+        jsonSchema={responseFormat?.json_schema}
+        onSave={handleSchemaSave}
+        onCancel={handleSchemaCancel}
+      />
+    )}
   </>;
 }


### PR DESCRIPTION
# Changelog

1. Add `json_schema` field and modal for `response_format`. Right now just doing a simple validation that it is indeed json before saving.
2. Added an example to showcase how to fill out the json schema with grading as an example
3. Also add `xhigh` to reasoning as per OpenAI docs: https://platform.openai.com/docs/guides/latest-model#new-features-in-gpt-5-2
